### PR TITLE
desktop: Remove --new-window to match eos-app

### DIFF
--- a/data/eos-file-manager.desktop.in.in
+++ b/data/eos-file-manager.desktop.in.in
@@ -2,7 +2,7 @@
 _Name=Files
 _Comment=Access and organize files
 _Keywords=folder;manager;explore;disk;filesystem;
-Exec=eos-file-manager --new-window %U
+Exec=eos-file-manager %U
 Icon=system-file-manager
 Terminal=false
 Type=Application


### PR DESCRIPTION
Now that the Exec field from the package's desktop file will be used,
remove --new-window to match what eos-app-eos-file-manager was doing.

[endlessm/eos-shell#5272]