### PR TITLE
places-sidebar: correctly calculate eject icon position

### DIFF
--- a/src/nautilus-places-sidebar.c
+++ b/src/nautilus-places-sidebar.c
@@ -988,7 +988,10 @@ over_eject_button (SidebarTreeData *data,
 		/* This is kinda weird, but we have to do it to workaround gtk+ expanding
 		 * the eject cell renderer (even thought we told it not to) and we then
 		 * had to set it right-aligned */
-		x_offset += width - hseparator - EJECT_BUTTON_XPAD - eject_button_size;
+		if (gtk_widget_get_direction (GTK_WIDGET (tree_view)) == GTK_TEXT_DIR_LTR)
+			x_offset += width - hseparator - EJECT_BUTTON_XPAD - eject_button_size;
+		else
+			x_offset += EJECT_BUTTON_XPAD;
 
 		if (x - x_offset >= 0 &&
 		    x - x_offset <= eject_button_size) {


### PR DESCRIPTION
Gtk+ doesn't change the coordinate system when dealing with
RTL locations. As a side effect, while it renders things
correctly regarding different text directions, custom code
shall handle that manually.

NautilusPlacesSidebar code actually didn't handle the RTL
state properly. To fix that, consider the RTL state when
calculating the eject button position.

Fixes #5554.